### PR TITLE
fix: added missing execserver resources config option

### DIFF
--- a/desktop/execserver.yml
+++ b/desktop/execserver.yml
@@ -4,6 +4,8 @@ fylr:
   debug:
     skipTerms: false
 
+  resources: "/fylr/files/resources"
+
   services:
     execserver:
       tempDir: /tmp/fylr

--- a/docker/config/execserver/fylr.yml
+++ b/docker/config/execserver/fylr.yml
@@ -4,6 +4,8 @@ fylr:
   debug:
     skipTerms: false
 
+  resources: "/fylr/files/resources"
+
   services:
     execserver:
       tempDir: /tmp/fylr

--- a/kubernetes/execserver/config/execserver.yaml
+++ b/kubernetes/execserver/config/execserver.yaml
@@ -5,6 +5,8 @@ fylr:
     level: "info"
     timeFormat: "2006-01-02 15:04:05"
 
+  resources: "/fylr/files/resources"
+
   services:
     execserver:
       addr: ":7070"


### PR DESCRIPTION
This PR adds the newly introduced `resource` Config dependency to the examples.

Fixes: #10 